### PR TITLE
Add mmap based index appening system

### DIFF
--- a/memindex_test.go
+++ b/memindex_test.go
@@ -39,8 +39,8 @@ func TestNewMemIndexNewFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if string(data) != "" {
-		t.Fatal("initially index should be empty")
+	if len(data) != PreAllocateSize {
+		t.Fatal("initially index should be pre-allocated")
 	}
 }
 


### PR DESCRIPTION
This reduces write latency for index writing a lot. (reduces ~1000ns)
- With this solution, we initially mmap the whole file.
- then try to parse it and fill the index
- once the parsing is done, we'll try to do reallocate if possible (only when there is no data in the file)
- If allocated, then we try to mmap again with the new data
- then when we are writing, we are trying to see if we need to re-allocate
- if allocated, try to mmap again with the new data
- then loop this process

Now with this solution, we are directly writing data to bytes and it gives super fast access.
